### PR TITLE
update for 0.17.0

### DIFF
--- a/xmonad.hs
+++ b/xmonad.hs
@@ -303,7 +303,7 @@ myLayoutHook = avoidStruts $ mouseResize $ windowArrange $ T.toggleLayouts float
                $ mkToggle (NBFULL ?? NOBORDERS ?? EOT) myDefaultLayout
              where
                myDefaultLayout =     withBorder myBorderWidth tall
-                                 ||| magnify
+                                 ||| Main.magnify
                                  ||| noBorders monocle
                                  ||| floats
                                  ||| noBorders tabs


### PR DESCRIPTION
This is backward compatible with earlier versions, but in 0.17.0 `magnify` is also exported by `XMonad.Layout.Magnifier` and causes a name conflict.